### PR TITLE
Label text

### DIFF
--- a/Classes/DatasetSerializer.cs
+++ b/Classes/DatasetSerializer.cs
@@ -1,0 +1,97 @@
+﻿using LabellingDB;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace OWE005336__Video_Annotation_Software_
+{
+     /// <summary>
+     // Handles exporting a train/validate/test dataset as a configuration yaml file and 3 files listing the images and their BBOXes. Based on Yolov5 format but modified for our purposes
+     /// </summary>
+    public class DatasetSerializer
+    {
+        public DatasetSerializerSettings Settings { get; set; } = new DatasetSerializerSettings();
+
+        public List<LabelledImage> TrainingDataset { get; } = new List<LabelledImage>();
+        public List<LabelledImage> ValidationDataset { get; } = new List<LabelledImage>();
+        public List<LabelledImage> TestDataset { get; } = new List<LabelledImage>();
+
+        public DatasetSerializer(DatasetSerializerSettings settings = null)
+        {
+            this.Settings = settings ?? this.Settings;
+        }
+
+        public void Serialize(string directory, string name, DateTime? dateCreated = null)
+        {
+            if (!dateCreated.HasValue)
+                dateCreated = DateTime.Now;
+
+            //Serialize each list of images into a separate file
+            SerializeDataset(Path.Combine(directory, Settings.TrainingDatasetFileName), TrainingDataset);
+            SerializeDataset(Path.Combine(directory, Settings.ValidationDatasetFileName), ValidationDataset);
+            SerializeDataset(Path.Combine(directory, Settings.TestDatasetFileName), TestDataset);
+
+            //Generate the configuration file
+            var configuration = new DatasetConfiguration() {
+                TrainingDataset = Settings.TrainingDatasetFileName,
+                ValidationDataset = Settings.ValidationDatasetFileName,
+                TestDataset = Settings.TestDatasetFileName,
+                Name = name,
+                DateCreated = dateCreated.Value
+            };
+
+            //Serialize the configuration file
+            var yamlSerializer = (new SerializerBuilder()).WithNamingConvention(PascalCaseNamingConvention.Instance).Build();
+            System.IO.File.AppendAllText(Path.Combine(directory, Settings.DefinitionFileName), yamlSerializer.Serialize(configuration));
+        }
+
+        protected void SerializeDataset(string filePath, IEnumerable<LabelledImage> images)
+        {
+            using(var x = new StreamWriter(filePath, false, Encoding.UTF8))
+            {
+                foreach (var img in images)
+                    x.WriteLine(SerializeLabelledImage(img, Settings.ImageDirectoryPrefix, Settings.ToLinux));
+            }
+        }
+
+        public static string SerializeLabelledImage(LabelledImage img, string directoryPrefix, bool to_linux)
+        {
+            var imagePath = Path.Combine(directoryPrefix, img.Filepath);
+
+            if (to_linux)
+                imagePath = imagePath.Replace(@"\", "/");
+
+            var imgSize = $"{img.ImageSize.Width} {img.ImageSize.Height}";
+            var labels = string.Join("|", img.LabelledROIs.Select(x => $"{x.LabelName},{x.ROI.X},{x.ROI.Y},{x.ROI.Width},{x.ROI.Height}"));
+            var line = $"{imagePath}|{imgSize}|{labels}";
+            return line;
+        }
+    }
+
+    public class DatasetSerializerSettings
+    {
+        public string DatasetFilePath { get; set; } = "";
+        public string ImageDirectoryPrefix { get; set; } = "";
+        public bool ToLinux { get; set; } = true;
+
+        public string DefinitionFileName { get; set; } = "dataset.yaml";
+        public string TrainingDatasetFileName { get; set; } = "training.yolo.txt";
+        public string ValidationDatasetFileName { get; set; } = "validation.yolo.txt";
+        public string TestDatasetFileName { get; set; } = "test.yolo.txt";
+    }
+
+    public class DatasetConfiguration
+    {
+        public DateTime DateCreated { get; set; }
+        public string Name { get; set; }
+        public string TrainingDataset { get; set; }
+        public string ValidationDataset { get; set; }
+        public string TestDataset { get; set; }
+    }
+}

--- a/Classes/ImageFolderLoader.cs
+++ b/Classes/ImageFolderLoader.cs
@@ -1,0 +1,110 @@
+﻿using LabellingDB;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OWE005336__Video_Annotation_Software_.Classes
+{
+    /// <summary>
+    /// When given a folder, will load all the images into a list of LabelledImages.
+    /// When asked to load images, will load thumbnails async and call the thumbnailLoaded event
+    /// </summary>
+    public class ImageFolderLoader
+    {
+        public string[] ImageFileExtensions = new string[] { ".png", ".jpg", ".bmp", ".gif" };
+        public string[] MetadataFileExtensions = new string[] { ".txt" };
+
+        public Dictionary<int, string> Detector_LabelMap = new Dictionary<int, string>() { { 0, "Rotary" }, { 1, "Fixed" }, { 2, "Bird" }, { 3,  "Tree" } }; //Mapping from the detector class IDs to labels
+
+        public string FolderPath { get; protected set; }
+        public ImageFolderLoader() { }
+
+        public void LoadFolder(string folderPath)
+        {
+            FolderPath = folderPath;
+
+            if (!Directory.Exists(folderPath))
+                throw new ArgumentException("folderPath is not a directory", nameof(folderPath));
+
+            foreach (var filePath in Directory.GetFiles(folderPath))
+            {
+                if (!ImageFileExtensions.Contains(Path.GetExtension(filePath)))
+                    continue;   //Ignore files that are not images
+
+                Image imgInfo;
+
+                //This should avoid loading the full image into memory to speed up the file reading
+                using (var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+                    imgInfo = Image.FromStream(fs, false, false);
+
+                LabelledImage img = new LabelledImage(imgInfo.Size);
+
+                //Look for metadata file containing ROIs
+                var roiDataFilePath = GetMetadataFile(folderPath, filePath);
+
+                if (roiDataFilePath != null)
+                {
+
+                }
+            }
+        }
+
+        private string GetMetadataFile(string folderPath, string filePath)
+        {
+            var fileName = Path.GetFileNameWithoutExtension(filePath);
+            string metadataFilePath = null;
+
+            foreach (var extension in MetadataFileExtensions)
+            {
+                var testFilePath = Path.Combine(folderPath, fileName + extension);
+                if (File.Exists(testFilePath))
+                {
+                    metadataFilePath = testFilePath;
+                    break;
+                }
+            }
+            return metadataFilePath;
+        }
+
+        public LabelledROI[] ReadROI(string filePath)
+        {
+            List<LabelledROI> rois = new List<LabelledROI>();
+
+            var lines = File.ReadAllLines(filePath);
+
+            foreach(var line in lines)
+            {
+                var fields = line.Split(' ');
+                if (fields.Length < 5)
+                    continue;
+
+                try
+                {
+                    int center_x = int.Parse(fields[1]);
+                    int center_y = int.Parse(fields[2]);
+                    int width = int.Parse(fields[3]);
+                    int height = int.Parse(fields[4]);
+                    //float confidence = float.Parse(fields[5]); // Not used
+
+                    string label = fields[0];
+                    int label_ID;
+                    if (int.TryParse(fields[0], out label_ID))
+                    {
+                        //This has come from the detector with just a class ID. Map to a label
+                        label = Detector_LabelMap[label_ID];
+                    }
+
+                    rois.Add(new LabelledROI(-1, -1, new Rectangle()));
+                }
+                catch (FormatException)
+                { 
+                    //One of the fields was invalid, ignore this line
+                }
+            }
+        }
+    }
+}

--- a/CustomControls/ROISelector.cs
+++ b/CustomControls/ROISelector.cs
@@ -493,6 +493,7 @@ namespace OWE005336__Video_Annotation_Software_
         private float _DefaultFontSize = 10;
         private Font _Font = new Font("Calibri", 10);
         private const int GRAB_WIDTH = 3;
+        public object Tag;
         public ROIObject(RectangleF roi, float scale, string name)
         {
             Name = name;

--- a/Forms/DialogForms/fProcessTrackerImages.Designer.cs
+++ b/Forms/DialogForms/fProcessTrackerImages.Designer.cs
@@ -29,10 +29,14 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle9 = new System.Windows.Forms.DataGridViewCellStyle();
             this.dgvImages = new System.Windows.Forms.DataGridView();
+            this.Thumbnail = new System.Windows.Forms.DataGridViewImageColumn();
+            this.FileName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.FilePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.MetadataFilePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.splitter1 = new System.Windows.Forms.Splitter();
             this.panel1 = new System.Windows.Forms.Panel();
             this.panel4 = new System.Windows.Forms.Panel();
@@ -43,6 +47,7 @@
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.lblAddedCount = new System.Windows.Forms.Label();
             this.lblImageCount = new System.Windows.Forms.Label();
+            this.tgbTags = new OWE005336__Video_Annotation_Software_.TagBox();
             this.label1 = new System.Windows.Forms.Label();
             this.cmbSensorType = new System.Windows.Forms.ComboBox();
             this.label2 = new System.Windows.Forms.Label();
@@ -51,12 +56,7 @@
             this.btnSelectLabel = new System.Windows.Forms.Button();
             this.Label = new System.Windows.Forms.Label();
             this.tips = new System.Windows.Forms.ToolTip(this.components);
-            this.tgbTags = new OWE005336__Video_Annotation_Software_.TagBox();
             this.roiSelector = new OWE005336__Video_Annotation_Software_.ROISelector();
-            this.Thumbnail = new System.Windows.Forms.DataGridViewImageColumn();
-            this.FileName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FilePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.MetadataFilePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(this.dgvImages)).BeginInit();
             this.panel1.SuspendLayout();
             this.panel4.SuspendLayout();
@@ -70,39 +70,39 @@
             this.dgvImages.AllowDrop = true;
             this.dgvImages.AllowUserToAddRows = false;
             this.dgvImages.AllowUserToDeleteRows = false;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvImages.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle7.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle7.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle7.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle7.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle7.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle7.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle7.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvImages.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle7;
             this.dgvImages.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dgvImages.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Thumbnail,
             this.FileName,
             this.FilePath,
             this.MetadataFilePath});
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvImages.DefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle8.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle8.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle8.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle8.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle8.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle8.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle8.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvImages.DefaultCellStyle = dataGridViewCellStyle8;
             this.dgvImages.Dock = System.Windows.Forms.DockStyle.Left;
             this.dgvImages.Location = new System.Drawing.Point(0, 0);
             this.dgvImages.Name = "dgvImages";
-            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvImages.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
+            dataGridViewCellStyle9.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle9.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle9.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle9.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle9.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle9.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle9.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvImages.RowHeadersDefaultCellStyle = dataGridViewCellStyle9;
             this.dgvImages.RowHeadersVisible = false;
             this.dgvImages.RowTemplate.Height = 50;
             this.dgvImages.RowTemplate.Resizable = System.Windows.Forms.DataGridViewTriState.False;
@@ -112,6 +112,32 @@
             this.dgvImages.SelectionChanged += new System.EventHandler(this.dgvImages_SelectionChanged);
             this.dgvImages.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dgvImages_KeyDown);
             this.dgvImages.KeyUp += new System.Windows.Forms.KeyEventHandler(this.dgvImages_KeyUp);
+            // 
+            // Thumbnail
+            // 
+            this.Thumbnail.HeaderText = "Thumbnail";
+            this.Thumbnail.ImageLayout = System.Windows.Forms.DataGridViewImageCellLayout.Zoom;
+            this.Thumbnail.Name = "Thumbnail";
+            this.Thumbnail.ReadOnly = true;
+            this.Thumbnail.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            this.Thumbnail.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            // 
+            // FileName
+            // 
+            this.FileName.HeaderText = "Name";
+            this.FileName.Name = "FileName";
+            // 
+            // FilePath
+            // 
+            this.FilePath.HeaderText = "File Path";
+            this.FilePath.Name = "FilePath";
+            this.FilePath.ReadOnly = true;
+            // 
+            // MetadataFilePath
+            // 
+            this.MetadataFilePath.HeaderText = "Metadata File Path";
+            this.MetadataFilePath.Name = "MetadataFilePath";
+            this.MetadataFilePath.ReadOnly = true;
             // 
             // splitter1
             // 
@@ -166,7 +192,9 @@
             this.btnFinish.Size = new System.Drawing.Size(75, 23);
             this.btnFinish.TabIndex = 11;
             this.btnFinish.Text = "Finish";
+            this.tips.SetToolTip(this.btnFinish, "Close");
             this.btnFinish.UseVisualStyleBackColor = true;
+            this.btnFinish.Click += new System.EventHandler(this.btnFinish_Click);
             // 
             // btnCancel
             // 
@@ -177,8 +205,9 @@
             this.btnCancel.Size = new System.Drawing.Size(41, 41);
             this.btnCancel.TabIndex = 2;
             this.btnCancel.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
-            this.tips.SetToolTip(this.btnCancel, "Reject Image");
+            this.tips.SetToolTip(this.btnCancel, "Reject & Delete Image");
             this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             // 
             // btnSave
             // 
@@ -221,6 +250,16 @@
             this.lblImageCount.Size = new System.Drawing.Size(41, 13);
             this.lblImageCount.TabIndex = 7;
             this.lblImageCount.Text = "Added:";
+            // 
+            // tgbTags
+            // 
+            this.tgbTags.AutoScroll = true;
+            this.tgbTags.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.tgbTags.Dock = System.Windows.Forms.DockStyle.Top;
+            this.tgbTags.Location = new System.Drawing.Point(5, 86);
+            this.tgbTags.Name = "tgbTags";
+            this.tgbTags.Size = new System.Drawing.Size(190, 117);
+            this.tgbTags.TabIndex = 15;
             // 
             // label1
             // 
@@ -294,16 +333,6 @@
             this.Label.TabIndex = 9;
             this.Label.Text = "Label";
             // 
-            // tgbTags
-            // 
-            this.tgbTags.AutoScroll = true;
-            this.tgbTags.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.tgbTags.Dock = System.Windows.Forms.DockStyle.Top;
-            this.tgbTags.Location = new System.Drawing.Point(5, 86);
-            this.tgbTags.Name = "tgbTags";
-            this.tgbTags.Size = new System.Drawing.Size(190, 117);
-            this.tgbTags.TabIndex = 15;
-            // 
             // roiSelector
             // 
             this.roiSelector.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -313,32 +342,6 @@
             this.roiSelector.Size = new System.Drawing.Size(1336, 607);
             this.roiSelector.TabIndex = 0;
             this.roiSelector.Text = "roiSelector1";
-            // 
-            // Thumbnail
-            // 
-            this.Thumbnail.HeaderText = "Thumbnail";
-            this.Thumbnail.ImageLayout = System.Windows.Forms.DataGridViewImageCellLayout.Zoom;
-            this.Thumbnail.Name = "Thumbnail";
-            this.Thumbnail.ReadOnly = true;
-            this.Thumbnail.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.Thumbnail.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            // 
-            // FileName
-            // 
-            this.FileName.HeaderText = "Name";
-            this.FileName.Name = "FileName";
-            // 
-            // FilePath
-            // 
-            this.FilePath.HeaderText = "File Path";
-            this.FilePath.Name = "FilePath";
-            this.FilePath.ReadOnly = true;
-            // 
-            // MetadataFilePath
-            // 
-            this.MetadataFilePath.HeaderText = "Metadata File Path";
-            this.MetadataFilePath.Name = "MetadataFilePath";
-            this.MetadataFilePath.ReadOnly = true;
             // 
             // fProcessTrackerImages
             // 

--- a/Forms/DialogForms/fProcessTrackerImages.Designer.cs
+++ b/Forms/DialogForms/fProcessTrackerImages.Designer.cs
@@ -28,27 +28,41 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
-            this.roiSelector = new OWE005336__Video_Annotation_Software_.ROISelector();
             this.dgvImages = new System.Windows.Forms.DataGridView();
             this.Thumbnail = new System.Windows.Forms.DataGridViewImageColumn();
+            this.FileName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.FilePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.splitter1 = new System.Windows.Forms.Splitter();
+            this.panel1 = new System.Windows.Forms.Panel();
+            this.panel4 = new System.Windows.Forms.Panel();
+            this.panel6 = new System.Windows.Forms.Panel();
+            this.btnFinish = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
             this.btnSave = new System.Windows.Forms.Button();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.lblAddedCount = new System.Windows.Forms.Label();
+            this.lblImageCount = new System.Windows.Forms.Label();
+            this.label1 = new System.Windows.Forms.Label();
+            this.cmbSensorType = new System.Windows.Forms.ComboBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.panel5 = new System.Windows.Forms.Panel();
+            this.txtLabel = new System.Windows.Forms.TextBox();
+            this.btnSelectLabel = new System.Windows.Forms.Button();
+            this.Label = new System.Windows.Forms.Label();
+            this.tips = new System.Windows.Forms.ToolTip(this.components);
+            this.tgbTags = new OWE005336__Video_Annotation_Software_.TagBox();
+            this.roiSelector = new OWE005336__Video_Annotation_Software_.ROISelector();
             ((System.ComponentModel.ISupportInitialize)(this.dgvImages)).BeginInit();
+            this.panel1.SuspendLayout();
+            this.panel4.SuspendLayout();
+            this.panel6.SuspendLayout();
+            this.groupBox1.SuspendLayout();
+            this.panel5.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // roiSelector
-            // 
-            this.roiSelector.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.roiSelector.Location = new System.Drawing.Point(0, 0);
-            this.roiSelector.Name = "roiSelector";
-            this.roiSelector.SelectedROIIndex = -1;
-            this.roiSelector.Size = new System.Drawing.Size(800, 450);
-            this.roiSelector.TabIndex = 0;
-            this.roiSelector.Text = "roiSelector1";
             // 
             // dgvImages
             // 
@@ -66,6 +80,7 @@
             this.dgvImages.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dgvImages.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Thumbnail,
+            this.FileName,
             this.FilePath});
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
@@ -90,9 +105,11 @@
             this.dgvImages.RowTemplate.Height = 50;
             this.dgvImages.RowTemplate.Resizable = System.Windows.Forms.DataGridViewTriState.False;
             this.dgvImages.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            this.dgvImages.Size = new System.Drawing.Size(268, 450);
+            this.dgvImages.Size = new System.Drawing.Size(268, 607);
             this.dgvImages.TabIndex = 10;
             this.dgvImages.SelectionChanged += new System.EventHandler(this.dgvImages_SelectionChanged);
+            this.dgvImages.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dgvImages_KeyDown);
+            this.dgvImages.KeyUp += new System.Windows.Forms.KeyEventHandler(this.dgvImages_KeyUp);
             // 
             // Thumbnail
             // 
@@ -102,6 +119,11 @@
             this.Thumbnail.ReadOnly = true;
             this.Thumbnail.Resizable = System.Windows.Forms.DataGridViewTriState.True;
             this.Thumbnail.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            // 
+            // FileName
+            // 
+            this.FileName.HeaderText = "Name";
+            this.FileName.Name = "FileName";
             // 
             // FilePath
             // 
@@ -114,34 +136,223 @@
             // 
             this.splitter1.Location = new System.Drawing.Point(268, 0);
             this.splitter1.Name = "splitter1";
-            this.splitter1.Size = new System.Drawing.Size(6, 450);
+            this.splitter1.Size = new System.Drawing.Size(6, 607);
             this.splitter1.TabIndex = 11;
             this.splitter1.TabStop = false;
             // 
+            // panel1
+            // 
+            this.panel1.Controls.Add(this.panel4);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Right;
+            this.panel1.Location = new System.Drawing.Point(1136, 0);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(200, 607);
+            this.panel1.TabIndex = 13;
+            // 
+            // panel4
+            // 
+            this.panel4.Controls.Add(this.panel6);
+            this.panel4.Controls.Add(this.tgbTags);
+            this.panel4.Controls.Add(this.label1);
+            this.panel4.Controls.Add(this.cmbSensorType);
+            this.panel4.Controls.Add(this.label2);
+            this.panel4.Controls.Add(this.panel5);
+            this.panel4.Controls.Add(this.Label);
+            this.panel4.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.panel4.Location = new System.Drawing.Point(0, 321);
+            this.panel4.Name = "panel4";
+            this.panel4.Padding = new System.Windows.Forms.Padding(5);
+            this.panel4.Size = new System.Drawing.Size(200, 286);
+            this.panel4.TabIndex = 14;
+            // 
+            // panel6
+            // 
+            this.panel6.Controls.Add(this.btnFinish);
+            this.panel6.Controls.Add(this.btnCancel);
+            this.panel6.Controls.Add(this.btnSave);
+            this.panel6.Controls.Add(this.groupBox1);
+            this.panel6.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panel6.Location = new System.Drawing.Point(5, 203);
+            this.panel6.Name = "panel6";
+            this.panel6.Padding = new System.Windows.Forms.Padding(5);
+            this.panel6.Size = new System.Drawing.Size(190, 78);
+            this.panel6.TabIndex = 19;
+            // 
+            // btnFinish
+            // 
+            this.btnFinish.Location = new System.Drawing.Point(112, 52);
+            this.btnFinish.Name = "btnFinish";
+            this.btnFinish.Size = new System.Drawing.Size(75, 23);
+            this.btnFinish.TabIndex = 11;
+            this.btnFinish.Text = "Finish";
+            this.btnFinish.UseVisualStyleBackColor = true;
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnCancel.Image = global::OWE005336__Video_Annotation_Software_.Properties.Resources.CancelIcon;
+            this.btnCancel.Location = new System.Drawing.Point(96, 7);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(41, 41);
+            this.btnCancel.TabIndex = 2;
+            this.btnCancel.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
+            this.tips.SetToolTip(this.btnCancel, "Reject Image");
+            this.btnCancel.UseVisualStyleBackColor = true;
+            // 
             // btnSave
             // 
-            this.btnSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnSave.Image = global::OWE005336__Video_Annotation_Software_.Properties.Resources.OkTick;
-            this.btnSave.Location = new System.Drawing.Point(747, 397);
+            this.btnSave.Location = new System.Drawing.Point(143, 7);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(41, 41);
-            this.btnSave.TabIndex = 12;
+            this.btnSave.TabIndex = 1;
             this.btnSave.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
+            this.tips.SetToolTip(this.btnSave, "Import Image");
             this.btnSave.UseVisualStyleBackColor = true;
             this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.lblAddedCount);
+            this.groupBox1.Controls.Add(this.lblImageCount);
+            this.groupBox1.Location = new System.Drawing.Point(8, 1);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(152, 47);
+            this.groupBox1.TabIndex = 10;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "Save";
+            // 
+            // lblAddedCount
+            // 
+            this.lblAddedCount.AutoSize = true;
+            this.lblAddedCount.Location = new System.Drawing.Point(46, 16);
+            this.lblAddedCount.Name = "lblAddedCount";
+            this.lblAddedCount.Size = new System.Drawing.Size(13, 13);
+            this.lblAddedCount.TabIndex = 9;
+            this.lblAddedCount.Text = "0";
+            // 
+            // lblImageCount
+            // 
+            this.lblImageCount.AutoSize = true;
+            this.lblImageCount.Location = new System.Drawing.Point(6, 16);
+            this.lblImageCount.Name = "lblImageCount";
+            this.lblImageCount.Size = new System.Drawing.Size(41, 13);
+            this.lblImageCount.TabIndex = 7;
+            this.lblImageCount.Text = "Added:";
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.label1.Location = new System.Drawing.Point(5, 73);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(31, 13);
+            this.label1.TabIndex = 12;
+            this.label1.Text = "Tags";
+            // 
+            // cmbSensorType
+            // 
+            this.cmbSensorType.Dock = System.Windows.Forms.DockStyle.Top;
+            this.cmbSensorType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cmbSensorType.FormattingEnabled = true;
+            this.cmbSensorType.Location = new System.Drawing.Point(5, 52);
+            this.cmbSensorType.Name = "cmbSensorType";
+            this.cmbSensorType.Size = new System.Drawing.Size(190, 21);
+            this.cmbSensorType.TabIndex = 17;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Dock = System.Windows.Forms.DockStyle.Top;
+            this.label2.Location = new System.Drawing.Point(5, 39);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(67, 13);
+            this.label2.TabIndex = 16;
+            this.label2.Text = "Sensor Type";
+            // 
+            // panel5
+            // 
+            this.panel5.Controls.Add(this.txtLabel);
+            this.panel5.Controls.Add(this.btnSelectLabel);
+            this.panel5.Dock = System.Windows.Forms.DockStyle.Top;
+            this.panel5.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.panel5.Location = new System.Drawing.Point(5, 18);
+            this.panel5.Name = "panel5";
+            this.panel5.Size = new System.Drawing.Size(190, 21);
+            this.panel5.TabIndex = 18;
+            // 
+            // txtLabel
+            // 
+            this.txtLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.txtLabel.Location = new System.Drawing.Point(0, 0);
+            this.txtLabel.Name = "txtLabel";
+            this.txtLabel.ReadOnly = true;
+            this.txtLabel.Size = new System.Drawing.Size(165, 20);
+            this.txtLabel.TabIndex = 11;
+            this.txtLabel.DoubleClick += new System.EventHandler(this.txtLabel_DoubleClick);
+            // 
+            // btnSelectLabel
+            // 
+            this.btnSelectLabel.Dock = System.Windows.Forms.DockStyle.Right;
+            this.btnSelectLabel.Location = new System.Drawing.Point(165, 0);
+            this.btnSelectLabel.Name = "btnSelectLabel";
+            this.btnSelectLabel.Size = new System.Drawing.Size(25, 21);
+            this.btnSelectLabel.TabIndex = 14;
+            this.btnSelectLabel.Text = "...";
+            this.btnSelectLabel.UseVisualStyleBackColor = true;
+            this.btnSelectLabel.Click += new System.EventHandler(this.btnSelectLabel_Click);
+            // 
+            // Label
+            // 
+            this.Label.AutoSize = true;
+            this.Label.Dock = System.Windows.Forms.DockStyle.Top;
+            this.Label.Location = new System.Drawing.Point(5, 5);
+            this.Label.Name = "Label";
+            this.Label.Size = new System.Drawing.Size(33, 13);
+            this.Label.TabIndex = 9;
+            this.Label.Text = "Label";
+            // 
+            // tgbTags
+            // 
+            this.tgbTags.AutoScroll = true;
+            this.tgbTags.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.tgbTags.Dock = System.Windows.Forms.DockStyle.Top;
+            this.tgbTags.Location = new System.Drawing.Point(5, 86);
+            this.tgbTags.Name = "tgbTags";
+            this.tgbTags.Size = new System.Drawing.Size(190, 117);
+            this.tgbTags.TabIndex = 15;
+            // 
+            // roiSelector
+            // 
+            this.roiSelector.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.roiSelector.Location = new System.Drawing.Point(0, 0);
+            this.roiSelector.Name = "roiSelector";
+            this.roiSelector.SelectedROIIndex = -1;
+            this.roiSelector.Size = new System.Drawing.Size(1336, 607);
+            this.roiSelector.TabIndex = 0;
+            this.roiSelector.Text = "roiSelector1";
             // 
             // fProcessTrackerImages
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
-            this.Controls.Add(this.btnSave);
+            this.ClientSize = new System.Drawing.Size(1336, 607);
+            this.Controls.Add(this.panel1);
             this.Controls.Add(this.splitter1);
             this.Controls.Add(this.dgvImages);
             this.Controls.Add(this.roiSelector);
             this.Name = "fProcessTrackerImages";
-            this.Text = "fProcessTrackerImages";
+            this.Text = "Review Images from CV System";
             ((System.ComponentModel.ISupportInitialize)(this.dgvImages)).EndInit();
+            this.panel1.ResumeLayout(false);
+            this.panel4.ResumeLayout(false);
+            this.panel4.PerformLayout();
+            this.panel6.ResumeLayout(false);
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.panel5.ResumeLayout(false);
+            this.panel5.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -151,8 +362,26 @@
         private ROISelector roiSelector;
         private System.Windows.Forms.DataGridView dgvImages;
         private System.Windows.Forms.Splitter splitter1;
-        private System.Windows.Forms.DataGridViewImageColumn Thumbnail;
-        private System.Windows.Forms.DataGridViewTextBoxColumn FilePath;
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.Panel panel4;
+        private System.Windows.Forms.Panel panel6;
+        private System.Windows.Forms.Button btnCancel;
         private System.Windows.Forms.Button btnSave;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.Label lblImageCount;
+        private TagBox tgbTags;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.ComboBox cmbSensorType;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.Panel panel5;
+        private System.Windows.Forms.TextBox txtLabel;
+        private System.Windows.Forms.Button btnSelectLabel;
+        private System.Windows.Forms.Label Label;
+        private System.Windows.Forms.Button btnFinish;
+        private System.Windows.Forms.ToolTip tips;
+        private System.Windows.Forms.DataGridViewImageColumn Thumbnail;
+        private System.Windows.Forms.DataGridViewTextBoxColumn FileName;
+        private System.Windows.Forms.DataGridViewTextBoxColumn FilePath;
+        private System.Windows.Forms.Label lblAddedCount;
     }
 }

--- a/Forms/DialogForms/fProcessTrackerImages.Designer.cs
+++ b/Forms/DialogForms/fProcessTrackerImages.Designer.cs
@@ -33,9 +33,6 @@
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
             this.dgvImages = new System.Windows.Forms.DataGridView();
-            this.Thumbnail = new System.Windows.Forms.DataGridViewImageColumn();
-            this.FileName = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.FilePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.splitter1 = new System.Windows.Forms.Splitter();
             this.panel1 = new System.Windows.Forms.Panel();
             this.panel4 = new System.Windows.Forms.Panel();
@@ -56,6 +53,10 @@
             this.tips = new System.Windows.Forms.ToolTip(this.components);
             this.tgbTags = new OWE005336__Video_Annotation_Software_.TagBox();
             this.roiSelector = new OWE005336__Video_Annotation_Software_.ROISelector();
+            this.Thumbnail = new System.Windows.Forms.DataGridViewImageColumn();
+            this.FileName = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.FilePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.MetadataFilePath = new System.Windows.Forms.DataGridViewTextBoxColumn();
             ((System.ComponentModel.ISupportInitialize)(this.dgvImages)).BeginInit();
             this.panel1.SuspendLayout();
             this.panel4.SuspendLayout();
@@ -81,7 +82,8 @@
             this.dgvImages.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Thumbnail,
             this.FileName,
-            this.FilePath});
+            this.FilePath,
+            this.MetadataFilePath});
             dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
             dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -110,27 +112,6 @@
             this.dgvImages.SelectionChanged += new System.EventHandler(this.dgvImages_SelectionChanged);
             this.dgvImages.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dgvImages_KeyDown);
             this.dgvImages.KeyUp += new System.Windows.Forms.KeyEventHandler(this.dgvImages_KeyUp);
-            // 
-            // Thumbnail
-            // 
-            this.Thumbnail.HeaderText = "Thumbnail";
-            this.Thumbnail.ImageLayout = System.Windows.Forms.DataGridViewImageCellLayout.Zoom;
-            this.Thumbnail.Name = "Thumbnail";
-            this.Thumbnail.ReadOnly = true;
-            this.Thumbnail.Resizable = System.Windows.Forms.DataGridViewTriState.True;
-            this.Thumbnail.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            // 
-            // FileName
-            // 
-            this.FileName.HeaderText = "Name";
-            this.FileName.Name = "FileName";
-            // 
-            // FilePath
-            // 
-            this.FilePath.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.FilePath.HeaderText = "File Path";
-            this.FilePath.Name = "FilePath";
-            this.FilePath.ReadOnly = true;
             // 
             // splitter1
             // 
@@ -333,6 +314,32 @@
             this.roiSelector.TabIndex = 0;
             this.roiSelector.Text = "roiSelector1";
             // 
+            // Thumbnail
+            // 
+            this.Thumbnail.HeaderText = "Thumbnail";
+            this.Thumbnail.ImageLayout = System.Windows.Forms.DataGridViewImageCellLayout.Zoom;
+            this.Thumbnail.Name = "Thumbnail";
+            this.Thumbnail.ReadOnly = true;
+            this.Thumbnail.Resizable = System.Windows.Forms.DataGridViewTriState.True;
+            this.Thumbnail.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+            // 
+            // FileName
+            // 
+            this.FileName.HeaderText = "Name";
+            this.FileName.Name = "FileName";
+            // 
+            // FilePath
+            // 
+            this.FilePath.HeaderText = "File Path";
+            this.FilePath.Name = "FilePath";
+            this.FilePath.ReadOnly = true;
+            // 
+            // MetadataFilePath
+            // 
+            this.MetadataFilePath.HeaderText = "Metadata File Path";
+            this.MetadataFilePath.Name = "MetadataFilePath";
+            this.MetadataFilePath.ReadOnly = true;
+            // 
             // fProcessTrackerImages
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -379,9 +386,10 @@
         private System.Windows.Forms.Label Label;
         private System.Windows.Forms.Button btnFinish;
         private System.Windows.Forms.ToolTip tips;
+        private System.Windows.Forms.Label lblAddedCount;
         private System.Windows.Forms.DataGridViewImageColumn Thumbnail;
         private System.Windows.Forms.DataGridViewTextBoxColumn FileName;
         private System.Windows.Forms.DataGridViewTextBoxColumn FilePath;
-        private System.Windows.Forms.Label lblAddedCount;
+        private System.Windows.Forms.DataGridViewTextBoxColumn MetadataFilePath;
     }
 }

--- a/Forms/DialogForms/fProcessTrackerImages.cs
+++ b/Forms/DialogForms/fProcessTrackerImages.cs
@@ -271,5 +271,15 @@ namespace OWE005336__Video_Annotation_Software_
                 e.Handled = true;
             }
         }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            dgvImages_KeyUp(sender, new KeyEventArgs(Keys.Delete));
+        }
+
+        private void btnFinish_Click(object sender, EventArgs e)
+        {
+            this.Close();
+        }
     }
 }

--- a/Forms/DialogForms/fProcessTrackerImages.cs
+++ b/Forms/DialogForms/fProcessTrackerImages.cs
@@ -9,6 +9,8 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.IO;
+using System.Text.RegularExpressions;
+using Accord;
 
 namespace OWE005336__Video_Annotation_Software_
 {
@@ -18,6 +20,15 @@ namespace OWE005336__Video_Annotation_Software_
         private string _CurrentFilePath;
         private Bitmap _CurrentImage;
         List<ROIObject> _CurrentROIs = new List<ROIObject>();
+
+        public Dictionary<int, string> Detector_LabelMap = new Dictionary<int, string>() { { 0, "ROTARY WING" }, { 1, "FIXED WING" }, { 2, "BIRD" }, { 3, "TREE" } };
+
+        public Dictionary<string, LabelNode> LabelMap = new Dictionary<string, LabelNode>();
+        public int LabelID { get; set; } = -1;
+        public string Tags { get; set; } = "";
+        public SensorTypeEnum SensorType { get; set; } = SensorTypeEnum.Daylight;
+
+        public int AddedCount = 0;
 
         public fProcessTrackerImages(string dirpath)
         {
@@ -32,7 +43,7 @@ namespace OWE005336__Video_Annotation_Software_
             foreach (string s in filePaths)
             {
                 _PaintDataInProgress.Lock();
-                dgvImages.Rows.Add(new object[] { null, s });
+                dgvImages.Rows.Add(new object[] { null, Path.GetFileName(s), s });
                 _PaintDataInProgress.Unlock();
             }
 
@@ -42,11 +53,32 @@ namespace OWE005336__Video_Annotation_Software_
             {
                 LoadThumbnail(i);
             }
+
+            cmbSensorType.DataSource = Enum.GetValues(typeof(SensorTypeEnum));
+            cmbSensorType.SelectedItem = SensorType;
+            cmbSensorType.SelectedIndexChanged += CmbSensorType_SelectedIndexChanged;
+            tgbTags.TagsChanged += TgbTags_TagsChanged;
+
+            //Cache a mapping of label names to IDs to match to labels from the detection results
+            var labels = Program.ImageDatabase.LabelTree_LoadLabelList();
+            foreach (var label in labels)
+                LabelMap.Add(label.Name.ToUpperInvariant(), label);
         }
+
+        private void TgbTags_TagsChanged(TagBox sender, EventArgs e)
+        {
+            Tags = sender.ToString();
+        }
+
+        private void CmbSensorType_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            SensorType = (SensorTypeEnum)cmbSensorType.SelectedItem;
+        }
+
         private async void LoadThumbnail(int row_index)
         {
             var cell = dgvImages.Rows[row_index].Cells[0];
-            string filepath = (string)dgvImages.Rows[row_index].Cells[1].Value;
+            string filepath = (string)dgvImages.Rows[row_index].Cells[2].Value;
 
             Image img = await Task.Run(() =>
             {
@@ -68,7 +100,7 @@ namespace OWE005336__Video_Annotation_Software_
             {
                 if (dgvImages.SelectedRows.Count > 0)
                 {
-                    _CurrentFilePath = (string)dgvImages.SelectedRows[0].Cells[1].Value;
+                    _CurrentFilePath = (string)dgvImages.SelectedRows[0].Cells[2].Value;
                     _CurrentImage = (Bitmap)LoadImage(_CurrentFilePath);
                     string txtfilepath = Path.ChangeExtension(_CurrentFilePath, ".txt");
 
@@ -81,31 +113,36 @@ namespace OWE005336__Video_Annotation_Software_
                         while (line != null)
                         {
                             string[] str_values = line.Split(' ');
-                            if (str_values.Length >= 5)
+
+                            try
                             {
-                                float[] values = new float[5];
-                                float val;
-                                bool success = true;
+                                if (str_values.Length < 5)
+                                    continue;
 
-                                for (int i=0; i < 5; i++)
-                                {
-                                    if (float.TryParse(str_values[i], out val))
-                                    {
-                                        values[i] = val;
-                                    }
-                                    else
-                                    {
-                                        success = false;
-                                        break;
-                                    }
-                                }
+                                LabelNode label = new LabelNode(-1, "<Unknown>", -1);
+                                var labelText = str_values[0];
+                                var topLeft_x = float.Parse(str_values[1]);
+                                var topLeft_y = float.Parse(str_values[2]);
+                                var width = float.Parse(str_values[3]);
+                                var height = float.Parse(str_values[4]);
+                                var confidence = str_values.Length >= 6 ? float.Parse(str_values[5]) : 1.0;
 
-                                if (success)
+                                //If label is a number assume it is a detector output ID, convert to text
+                                if (int.TryParse(labelText, out int dectectorClassID))
                                 {
-                                    string description = (str_values.Length >= 6) ? str_values[5]: "";
-                                    ROIObject roi = new ROIObject(new RectangleF(values[1], values[2], values[3], values[4]), 1, description);
-                                    _CurrentROIs.Add(roi);
+                                    labelText = Detector_LabelMap[dectectorClassID];
                                 }
+                                //Try and get the label ID for the given label
+
+                                if (LabelMap.TryGetValue(labelText, out LabelNode matchedlabel))
+                                    label = matchedlabel;
+
+                                _CurrentROIs.Add(new ROIObject(new RectangleF(topLeft_x, topLeft_y, width, height), 1, label.Name) { Tag = label });
+                            }
+                            catch (FormatException)
+                            {
+                                // The line was incorrectly formatted, ignore
+                                continue;
                             }
                             line = fs.ReadLine();
                         }
@@ -115,6 +152,8 @@ namespace OWE005336__Video_Annotation_Software_
                 }
                 else
                 {
+                    _CurrentImage = null;
+                    _CurrentROIs.Clear();
                     roiSelector.LinkToLabelledImage(new List<ROIObject>(), null);
                 }
             }
@@ -128,16 +167,26 @@ namespace OWE005336__Video_Annotation_Software_
             return Image.FromStream(ms);
         }
 
+        protected void RemoveImageFromList(int index)
+        {
+
+            _PaintDataInProgress.Lock();
+            dgvImages.Rows.RemoveAt(index);
+            _PaintDataInProgress.Unlock();
+
+            dgvImages_SelectionChanged(dgvImages, new EventArgs());
+        }
         private async void btnSave_Click(object sender, EventArgs e)
         {
-            string newFileName = (string)dgvImages.SelectedRows[0].Cells[1].Value;
+            DataGridViewRow selectedRow = dgvImages.SelectedRows[0];
+            string newFileName = (string)selectedRow.Cells[1].Value;
             newFileName = Path.ChangeExtension(newFileName, ".png");
+            Tags = tgbTags.ToString();
 
             LabelledImage temp = Program.ImageDatabase.Images_SearchByFileName(Path.Combine("%", newFileName) + "%");
-
             if (temp == null)
             {
-                LabelledImage lImg = await Program.ImageDatabase.Images_Add(_CurrentImage, newFileName, SensorTypeEnum.Daylight);
+                LabelledImage lImg = await Program.ImageDatabase.Images_Add(_CurrentImage, newFileName, SensorType, LabelID, Tags);
 
                 if (lImg != null)
                 {
@@ -145,13 +194,70 @@ namespace OWE005336__Video_Annotation_Software_
                     {
                         RectangleF rectf = roi.GetROI();
                         Rectangle rect = new Rectangle((int)rectf.X, (int)rectf.Y, (int)rectf.Width, (int)rectf.Height);
-                        Program.ImageDatabase.BBoxLabels_AddLabel(lImg.ID, rect, -1);
+                        LabelNode label = roi.Tag as LabelNode;
+                        Program.ImageDatabase.BBoxLabels_AddLabel(lImg.ID, rect, label?.ID ?? -1);
                     }
                 }
+                int selectedIndex = selectedRow.Index;
+                RemoveImageFromList(selectedIndex);
+                if (dgvImages.Rows.Count > selectedIndex)
+                    dgvImages.Rows[selectedIndex].Selected = true;
+
+                AddedCount += 1;
+                lblAddedCount.Text = AddedCount.ToString();
             }
             else
             {
                 MessageBox.Show("Image already exists in database.");
+            }
+        }
+
+        private void btnSelectLabel_Click(object sender, EventArgs e)
+        {
+            fLabelSelector labelSelector = new fLabelSelector();
+
+            if (labelSelector.ShowDialog() == DialogResult.OK)
+            {
+                if (labelSelector.SelectedLabel.ParentID > -1)
+                {
+                    LabelID = labelSelector.SelectedLabel.ID;
+                    txtLabel.Text = labelSelector.SelectedLabel.Name;
+                }
+            }
+        }
+
+        private void txtLabel_DoubleClick(object sender, EventArgs e)
+        {
+            btnSelectLabel_Click(sender, e);
+        }
+
+        private void dgvImages_KeyUp(object sender, KeyEventArgs e)
+        {
+
+            if (e.KeyCode == Keys.Delete && dgvImages.SelectedRows.Count > 0)
+            {
+                int firstSelectedIndex = dgvImages.SelectedRows[0].Index;
+                foreach (DataGridViewRow row in dgvImages.SelectedRows)
+                {
+                    RemoveImageFromList(row.Index);
+                }
+                if (dgvImages.Rows.Count > firstSelectedIndex)
+                    dgvImages.Rows[firstSelectedIndex].Selected = true;
+            }
+            else if (e.KeyCode == Keys.Enter || e.KeyCode == Keys.Return)
+            {
+                var rows = dgvImages.SelectedRows;
+                btnSave_Click(sender, e);
+                e.Handled = true;
+            }
+        }
+
+        private void dgvImages_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Enter || e.KeyCode == Keys.Return)
+            {
+                //Handle this event to stop the automatic behaviour of moving to the next row
+                e.Handled = true;
             }
         }
     }

--- a/Forms/DialogForms/fProcessTrackerImages.resx
+++ b/Forms/DialogForms/fProcessTrackerImages.resx
@@ -126,6 +126,9 @@
   <metadata name="FilePath.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="MetadataFilePath.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="tips.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>

--- a/Forms/DialogForms/fProcessTrackerImages.resx
+++ b/Forms/DialogForms/fProcessTrackerImages.resx
@@ -120,7 +120,13 @@
   <metadata name="Thumbnail.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="FileName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="FilePath.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
+  </metadata>
+  <metadata name="tips.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
 </root>

--- a/Forms/fClassificationExport.Designer.cs
+++ b/Forms/fClassificationExport.Designer.cs
@@ -28,10 +28,17 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             this.panel1 = new System.Windows.Forms.Panel();
             this.txtSQL = new System.Windows.Forms.TextBox();
             this.splitter2 = new System.Windows.Forms.Splitter();
             this.panel3 = new System.Windows.Forms.Panel();
+            this.label9 = new System.Windows.Forms.Label();
+            this.label10 = new System.Windows.Forms.Label();
+            this.nudMinPixelsTest = new System.Windows.Forms.NumericUpDown();
+            this.label7 = new System.Windows.Forms.Label();
+            this.label8 = new System.Windows.Forms.Label();
+            this.nudMinPixelsValidation = new System.Windows.Forms.NumericUpDown();
             this.label6 = new System.Windows.Forms.Label();
             this.label5 = new System.Windows.Forms.Label();
             this.nudMinPixelsTrain = new System.Windows.Forms.NumericUpDown();
@@ -55,14 +62,11 @@
             this.dgvResults = new System.Windows.Forms.DataGridView();
             this.panel4 = new System.Windows.Forms.Panel();
             this.label4 = new System.Windows.Forms.Label();
-            this.label7 = new System.Windows.Forms.Label();
-            this.label8 = new System.Windows.Forms.Label();
-            this.nudMinPixelsValidation = new System.Windows.Forms.NumericUpDown();
-            this.label9 = new System.Windows.Forms.Label();
-            this.label10 = new System.Windows.Forms.Label();
-            this.nudMinPixelsTest = new System.Windows.Forms.NumericUpDown();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.panel1.SuspendLayout();
             this.panel3.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudMinPixelsTest)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudMinPixelsValidation)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMinPixelsTrain)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudTrainPct)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudTestPct)).BeginInit();
@@ -71,8 +75,6 @@
             this.panel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dgvResults)).BeginInit();
             this.panel4.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMinPixelsValidation)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMinPixelsTest)).BeginInit();
             this.SuspendLayout();
             // 
             // panel1
@@ -132,6 +134,66 @@
             this.panel3.Size = new System.Drawing.Size(828, 71);
             this.panel3.TabIndex = 12;
             // 
+            // label9
+            // 
+            this.label9.AutoSize = true;
+            this.label9.Location = new System.Drawing.Point(380, 49);
+            this.label9.Name = "label9";
+            this.label9.Size = new System.Drawing.Size(103, 13);
+            this.label9.TabIndex = 20;
+            this.label9.Text = "Min Test Image Size";
+            // 
+            // label10
+            // 
+            this.label10.AutoSize = true;
+            this.label10.Location = new System.Drawing.Point(574, 49);
+            this.label10.Name = "label10";
+            this.label10.Size = new System.Drawing.Size(33, 13);
+            this.label10.TabIndex = 19;
+            this.label10.Text = "pixels";
+            // 
+            // nudMinPixelsTest
+            // 
+            this.nudMinPixelsTest.Location = new System.Drawing.Point(510, 47);
+            this.nudMinPixelsTest.Maximum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            0});
+            this.nudMinPixelsTest.Name = "nudMinPixelsTest";
+            this.nudMinPixelsTest.Size = new System.Drawing.Size(63, 20);
+            this.nudMinPixelsTest.TabIndex = 18;
+            // 
+            // label7
+            // 
+            this.label7.AutoSize = true;
+            this.label7.Location = new System.Drawing.Point(380, 26);
+            this.label7.Name = "label7";
+            this.label7.Size = new System.Drawing.Size(128, 13);
+            this.label7.TabIndex = 17;
+            this.label7.Text = "Min Validation Image Size";
+            // 
+            // label8
+            // 
+            this.label8.AutoSize = true;
+            this.label8.Location = new System.Drawing.Point(574, 26);
+            this.label8.Name = "label8";
+            this.label8.Size = new System.Drawing.Size(33, 13);
+            this.label8.TabIndex = 16;
+            this.label8.Text = "pixels";
+            // 
+            // nudMinPixelsValidation
+            // 
+            this.nudMinPixelsValidation.Location = new System.Drawing.Point(510, 24);
+            this.nudMinPixelsValidation.Maximum = new decimal(new int[] {
+            100000,
+            0,
+            0,
+            0});
+            this.nudMinPixelsValidation.Name = "nudMinPixelsValidation";
+            this.nudMinPixelsValidation.Size = new System.Drawing.Size(63, 20);
+            this.nudMinPixelsValidation.TabIndex = 15;
+            // 
             // label6
             // 
             this.label6.AutoSize = true;
@@ -171,6 +233,7 @@
             this.btnSave.Size = new System.Drawing.Size(41, 41);
             this.btnSave.TabIndex = 2;
             this.btnSave.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
+            this.toolTip1.SetToolTip(this.btnSave, "Save query text and generate images");
             this.btnSave.UseVisualStyleBackColor = true;
             this.btnSave.Click += new System.EventHandler(this.btnSave_Click);
             // 
@@ -359,66 +422,6 @@
             this.label4.TabIndex = 17;
             this.label4.Text = "Output Directory";
             // 
-            // label7
-            // 
-            this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(380, 26);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(128, 13);
-            this.label7.TabIndex = 17;
-            this.label7.Text = "Min Validation Image Size";
-            // 
-            // label8
-            // 
-            this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(574, 26);
-            this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(33, 13);
-            this.label8.TabIndex = 16;
-            this.label8.Text = "pixels";
-            // 
-            // nudMinPixelsValidation
-            // 
-            this.nudMinPixelsValidation.Location = new System.Drawing.Point(510, 24);
-            this.nudMinPixelsValidation.Maximum = new decimal(new int[] {
-            100000,
-            0,
-            0,
-            0});
-            this.nudMinPixelsValidation.Name = "nudMinPixelsValidation";
-            this.nudMinPixelsValidation.Size = new System.Drawing.Size(63, 20);
-            this.nudMinPixelsValidation.TabIndex = 15;
-            // 
-            // label9
-            // 
-            this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(380, 49);
-            this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(103, 13);
-            this.label9.TabIndex = 20;
-            this.label9.Text = "Min Test Image Size";
-            // 
-            // label10
-            // 
-            this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(574, 49);
-            this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(33, 13);
-            this.label10.TabIndex = 19;
-            this.label10.Text = "pixels";
-            // 
-            // nudMinPixelsTest
-            // 
-            this.nudMinPixelsTest.Location = new System.Drawing.Point(510, 47);
-            this.nudMinPixelsTest.Maximum = new decimal(new int[] {
-            100000,
-            0,
-            0,
-            0});
-            this.nudMinPixelsTest.Name = "nudMinPixelsTest";
-            this.nudMinPixelsTest.Size = new System.Drawing.Size(63, 20);
-            this.nudMinPixelsTest.TabIndex = 18;
-            // 
             // fClassificationExport
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -428,11 +431,13 @@
             this.Controls.Add(this.splitter1);
             this.Controls.Add(this.panel1);
             this.Name = "fClassificationExport";
-            this.Text = "fClassificationExport";
+            this.Text = "Export Images for Classifier Training";
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
             this.panel3.ResumeLayout(false);
             this.panel3.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.nudMinPixelsTest)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudMinPixelsValidation)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMinPixelsTrain)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudTrainPct)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudTestPct)).EndInit();
@@ -442,8 +447,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.dgvResults)).EndInit();
             this.panel4.ResumeLayout(false);
             this.panel4.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMinPixelsValidation)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.nudMinPixelsTest)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -483,5 +486,6 @@
         private System.Windows.Forms.Label label7;
         private System.Windows.Forms.Label label8;
         private System.Windows.Forms.NumericUpDown nudMinPixelsValidation;
+        private System.Windows.Forms.ToolTip toolTip1;
     }
 }

--- a/Forms/fClassificationExport.Designer.cs
+++ b/Forms/fClassificationExport.Designer.cs
@@ -63,6 +63,7 @@
             this.panel4 = new System.Windows.Forms.Panel();
             this.label4 = new System.Windows.Forms.Label();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.btnOpenPrevScript = new System.Windows.Forms.Button();
             this.panel1.SuspendLayout();
             this.panel3.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudMinPixelsTest)).BeginInit();
@@ -109,6 +110,7 @@
             // 
             // panel3
             // 
+            this.panel3.Controls.Add(this.btnOpenPrevScript);
             this.panel3.Controls.Add(this.label9);
             this.panel3.Controls.Add(this.label10);
             this.panel3.Controls.Add(this.nudMinPixelsTest);
@@ -422,6 +424,19 @@
             this.label4.TabIndex = 17;
             this.label4.Text = "Output Directory";
             // 
+            // btnOpenPrevScript
+            // 
+            this.btnOpenPrevScript.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.btnOpenPrevScript.Image = global::OWE005336__Video_Annotation_Software_.Properties.Resources._1200px_OneDrive_Folder_Icon__32x32_;
+            this.btnOpenPrevScript.Location = new System.Drawing.Point(696, 17);
+            this.btnOpenPrevScript.Name = "btnOpenPrevScript";
+            this.btnOpenPrevScript.Size = new System.Drawing.Size(41, 41);
+            this.btnOpenPrevScript.TabIndex = 21;
+            this.btnOpenPrevScript.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageAboveText;
+            this.toolTip1.SetToolTip(this.btnOpenPrevScript, "Open previous export script");
+            this.btnOpenPrevScript.UseVisualStyleBackColor = true;
+            this.btnOpenPrevScript.Click += new System.EventHandler(this.btnOpenPrevScript_Click);
+            // 
             // fClassificationExport
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -487,5 +502,6 @@
         private System.Windows.Forms.Label label8;
         private System.Windows.Forms.NumericUpDown nudMinPixelsValidation;
         private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.Button btnOpenPrevScript;
     }
 }

--- a/Forms/fClassificationExport.resx
+++ b/Forms/fClassificationExport.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/Forms/fMain.Designer.cs
+++ b/Forms/fMain.Designer.cs
@@ -29,9 +29,9 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
             this.menuStrip1 = new System.Windows.Forms.MenuStrip();
             this.mniFile = new System.Windows.Forms.ToolStripMenuItem();
             this.mniOpen = new System.Windows.Forms.ToolStripMenuItem();
@@ -44,6 +44,7 @@
             this.mniReviewTestData = new System.Windows.Forms.ToolStripMenuItem();
             this.mniImportCOCOImages = new System.Windows.Forms.ToolStripMenuItem();
             this.mniReviewTrackerImages = new System.Windows.Forms.ToolStripMenuItem();
+            this.mniExportClassificationimages = new System.Windows.Forms.ToolStripMenuItem();
             this.tbcOptions = new System.Windows.Forms.TabControl();
             this.tbpImages = new System.Windows.Forms.TabPage();
             this.dgvImages = new System.Windows.Forms.DataGridView();
@@ -80,7 +81,7 @@
             this.stsStatus = new System.Windows.Forms.StatusStrip();
             this.lblConnectedUser = new System.Windows.Forms.ToolStripStatusLabel();
             this.lbiImage = new OWE005336__Video_Annotation_Software_.LabellingInterface();
-            this.mniExportClassificationimages = new System.Windows.Forms.ToolStripMenuItem();
+            this.tips = new System.Windows.Forms.ToolTip(this.components);
             this.menuStrip1.SuspendLayout();
             this.tbcOptions.SuspendLayout();
             this.tbpImages.SuspendLayout();
@@ -191,6 +192,13 @@
             this.mniReviewTrackerImages.Text = "Review Tracker Images";
             this.mniReviewTrackerImages.Click += new System.EventHandler(this.mniReviewTrackerImages_Click);
             // 
+            // mniExportClassificationimages
+            // 
+            this.mniExportClassificationimages.Name = "mniExportClassificationimages";
+            this.mniExportClassificationimages.Size = new System.Drawing.Size(222, 22);
+            this.mniExportClassificationimages.Text = "Export Classification Images";
+            this.mniExportClassificationimages.Click += new System.EventHandler(this.mniExportClassificationimages_Click);
+            // 
             // tbcOptions
             // 
             this.tbcOptions.Controls.Add(this.tbpImages);
@@ -221,38 +229,38 @@
             this.dgvImages.AllowDrop = true;
             this.dgvImages.AllowUserToAddRows = false;
             this.dgvImages.AllowUserToDeleteRows = false;
-            dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvImages.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle4.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle4.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle4.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle4.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvImages.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle4;
             this.dgvImages.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.dgvImages.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Thumbnail,
             this.Complete,
             this.FilePath});
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
-            this.dgvImages.DefaultCellStyle = dataGridViewCellStyle2;
+            dataGridViewCellStyle5.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.Window;
+            dataGridViewCellStyle5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle5.ForeColor = System.Drawing.SystemColors.ControlText;
+            dataGridViewCellStyle5.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle5.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle5.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.dgvImages.DefaultCellStyle = dataGridViewCellStyle5;
             this.dgvImages.Dock = System.Windows.Forms.DockStyle.Fill;
             this.dgvImages.Location = new System.Drawing.Point(3, 3);
             this.dgvImages.Name = "dgvImages";
-            dataGridViewCellStyle3.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.Control;
-            dataGridViewCellStyle3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            dataGridViewCellStyle3.ForeColor = System.Drawing.SystemColors.WindowText;
-            dataGridViewCellStyle3.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle3.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle3.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this.dgvImages.RowHeadersDefaultCellStyle = dataGridViewCellStyle3;
+            dataGridViewCellStyle6.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle6.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle6.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle6.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle6.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle6.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            this.dgvImages.RowHeadersDefaultCellStyle = dataGridViewCellStyle6;
             this.dgvImages.RowHeadersVisible = false;
             this.dgvImages.RowTemplate.Height = 50;
             this.dgvImages.RowTemplate.Resizable = System.Windows.Forms.DataGridViewTriState.False;
@@ -420,6 +428,7 @@
             this.btnCreateComposite.Name = "btnCreateComposite";
             this.btnCreateComposite.Size = new System.Drawing.Size(41, 41);
             this.btnCreateComposite.TabIndex = 2;
+            this.tips.SetToolTip(this.btnCreateComposite, "Create Composite Images");
             this.btnCreateComposite.UseVisualStyleBackColor = true;
             this.btnCreateComposite.Click += new System.EventHandler(this.btnCreateComposite_Click);
             // 
@@ -431,6 +440,7 @@
             this.btnOpenImages.Name = "btnOpenImages";
             this.btnOpenImages.Size = new System.Drawing.Size(41, 41);
             this.btnOpenImages.TabIndex = 1;
+            this.tips.SetToolTip(this.btnOpenImages, "Import folder of images");
             this.btnOpenImages.UseVisualStyleBackColor = true;
             this.btnOpenImages.Click += new System.EventHandler(this.btnOpenImages_Click);
             // 
@@ -442,6 +452,7 @@
             this.btnOpenVideo.Name = "btnOpenVideo";
             this.btnOpenVideo.Size = new System.Drawing.Size(41, 41);
             this.btnOpenVideo.TabIndex = 0;
+            this.tips.SetToolTip(this.btnOpenVideo, "Import Frames from Video");
             this.btnOpenVideo.UseVisualStyleBackColor = true;
             this.btnOpenVideo.Click += new System.EventHandler(this.btnOpenVideo_Click);
             // 
@@ -598,13 +609,6 @@
             this.lbiImage.Size = new System.Drawing.Size(923, 693);
             this.lbiImage.TabIndex = 4;
             // 
-            // mniExportClassificationimages
-            // 
-            this.mniExportClassificationimages.Name = "mniExportClassificationimages";
-            this.mniExportClassificationimages.Size = new System.Drawing.Size(222, 22);
-            this.mniExportClassificationimages.Text = "Export Classification Images";
-            this.mniExportClassificationimages.Click += new System.EventHandler(this.mniExportClassificationimages_Click);
-            // 
             // fMain
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -689,6 +693,7 @@
         private System.Windows.Forms.ToolStripMenuItem mniImportCOCOImages;
         private System.Windows.Forms.ToolStripMenuItem mniReviewTrackerImages;
         private System.Windows.Forms.ToolStripMenuItem mniExportClassificationimages;
+        private System.Windows.Forms.ToolTip tips;
     }
 }
 

--- a/Forms/fMain.cs
+++ b/Forms/fMain.cs
@@ -13,6 +13,7 @@ using System.Data;
 using System.Data.Sql;
 using System.Data.SqlClient;
 using LabellingDB;
+using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace OWE005336__Video_Annotation_Software_
 {
@@ -814,13 +815,18 @@ namespace OWE005336__Video_Annotation_Software_
 
         private void mniReviewTrackerImages_Click(object sender, EventArgs e)
         {
-            using (FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog())
+            var folderBrowserDialog = new CommonOpenFileDialog()
             {
-                if (folderBrowserDialog.ShowDialog() == DialogResult.OK)
-                {
-                    fProcessTrackerImages form = new fProcessTrackerImages(folderBrowserDialog.SelectedPath);
-                    form.ShowDialog();
-                }
+                AllowNonFileSystemItems = false,
+                Multiselect = false,
+                IsFolderPicker = true,
+                Title = "Select folder with images to import"
+            };
+
+            if (folderBrowserDialog.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                fProcessTrackerImages form = new fProcessTrackerImages(folderBrowserDialog.FileName);
+                form.ShowDialog();
             }
         }
 

--- a/Forms/fMain.resx
+++ b/Forms/fMain.resx
@@ -129,6 +129,12 @@
   <metadata name="FilePath.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="tips.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>232, 17</value>
+  </metadata>
+  <metadata name="tips.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>232, 17</value>
+  </metadata>
   <metadata name="stsStatus.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>132, 17</value>
   </metadata>

--- a/LabellingDB/ImageDatabaseAccess.cs
+++ b/LabellingDB/ImageDatabaseAccess.cs
@@ -1731,6 +1731,11 @@ namespace LabellingDB
 
         public bool UpdateClassificationExportTask(ClassificationExportTask task)
         {
+            if (task.ID < 0)
+            {
+                //This represents a task that isn't actually stored in the database, e.g. a historic task loaded from a file.
+                return false;
+            }
             bool success = false;
             SqlConnection conn = new SqlConnection(_ConnectionString);
             SqlCommand cmd = new SqlCommand("UPDATE classificationexporttasks SET classificationexporttasks.name = @name, classificationexporttasks.sql = @sql, " + 

--- a/OWE005336 (Video Annotation Software).csproj
+++ b/OWE005336 (Video Annotation Software).csproj
@@ -96,6 +96,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Classes\PaintLocker.cs" />
+    <Compile Include="Classes\DatasetSerializer.cs" />
     <Compile Include="CustomControls\ClipSelector.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/OWE005336 (Video Annotation Software).csproj
+++ b/OWE005336 (Video Annotation Software).csproj
@@ -90,6 +90,9 @@
     <Reference Include="Windows">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\Windows.winmd</HintPath>
     </Reference>
+    <Reference Include="YamlDotNet, Version=11.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
+      <HintPath>packages\YamlDotNet.11.1.1\lib\net45\YamlDotNet.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Classes\PaintLocker.cs" />

--- a/OWE005336 (Video Annotation Software).csproj
+++ b/OWE005336 (Video Annotation Software).csproj
@@ -50,6 +50,15 @@
     <Reference Include="FFmpeg.AutoGen, Version=4.3.0.1, Culture=neutral, PublicKeyToken=9b7632533a381715, processorArchitecture=MSIL">
       <HintPath>packages\FFmpeg.AutoGen.4.3.0.1\lib\net45\FFmpeg.AutoGen.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.WindowsAPICodePack-Core.1.1.0.0\lib\Microsoft.WindowsAPICodePack.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.WindowsAPICodePack-Shell.1.1.0.0\lib\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack.ShellExtensions, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.WindowsAPICodePack-Shell.1.1.0.0\lib\Microsoft.WindowsAPICodePack.ShellExtensions.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/packages.config
+++ b/packages.config
@@ -11,4 +11,5 @@
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
   <package id="System.Security.Cryptography.ProtectedData" version="4.7.0" targetFramework="net461" />
+  <package id="YamlDotNet" version="11.1.1" targetFramework="net461" />
 </packages>

--- a/packages.config
+++ b/packages.config
@@ -5,6 +5,8 @@
   <package id="Accord.Video.FFMPEG" version="3.8.0" targetFramework="net461" />
   <package id="FFMediaToolkit" version="3.1.1" targetFramework="net461" />
   <package id="FFmpeg.AutoGen" version="4.3.0.1" targetFramework="net461" />
+  <package id="Microsoft.WindowsAPICodePack-Core" version="1.1.0.0" targetFramework="net461" />
+  <package id="Microsoft.WindowsAPICodePack-Shell" version="1.1.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.Memory" version="4.5.4" targetFramework="net461" />


### PR DESCRIPTION
Adds a TextID field to each label. This allows gives a text-based ID which can be used during import and export of configuration data.

Using a text-based ID makes files referencing labels/classes (e.g. classifier configuration files, detection log files) easier to read, as the text ID gives some indication of what the class being referred to is.